### PR TITLE
handle windowClosing

### DIFF
--- a/src/dorkbox/notify/NotifyPopupWindowAdapter.java
+++ b/src/dorkbox/notify/NotifyPopupWindowAdapter.java
@@ -30,4 +30,11 @@ class NotifyPopupWindowAdapter extends WindowAdapter {
             //requestFocusInWindow();
         }
     }
+    public
+    void windowClosing(WindowEvent e) {
+        if (e.getNewState() != WindowEvent.WINDOW_CLOSED) {
+            NotifyPopup source = (NotifyPopup) e.getSource();
+            source.close();
+        }
+    }
 }


### PR DESCRIPTION
Add windowClosing handler to NotifyPopupWindowAdapter so you can context-click on a task bar icon and close it from there versus the popup itself.