### PR TITLE
Add Support for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "dorkbox"


### PR DESCRIPTION
Added [dependabot.yml](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file) to have Dependabot check for and open PRs to update each of the project's dependencies, once per month. This will help to keep the project up to date.